### PR TITLE
Fixes to uhdm-frontend to match with current yosys mainline

### DIFF
--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -1577,6 +1577,10 @@ void UhdmAst::process_stream_op()  {
 	loop_node->children.push_back(new AST::AstNode(AST::AST_BLOCK, assign_node));
 
 	block_node->children.push_back(new AST::AstNode(AST::AST_BLOCK, loop_node));
+	// Yosys requires that AST_BLOCK str was set
+	block_node->children[1]->str = "\\stream_op_block" + std::to_string(loop_id);
+	block_node->children[1]->children[0]->children[3]->str = "\\stream_op_block" + std::to_string(loop_id);
+
 	// Do not create a node
 	shared.report.mark_handled(obj_h);
 }

--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -2029,7 +2029,7 @@ void UhdmAst::process_function() {
 					 [&](AST::AstNode* node) {
 						 if (node) {
 							 current_node->children.push_back(node);
-							 node->str = current_node->str;
+							 node->str = "$result";
 						 }
 					 });
 	visit_one_to_many({vpiIODecl},


### PR DESCRIPTION
This fixes are required to match code with current mainline yosys version.