### PR TITLE
Support OpenTitan AES modules in the UHDM plugin

### DIFF
--- a/uhdm-plugin/UhdmAst.h
+++ b/uhdm-plugin/UhdmAst.h
@@ -67,6 +67,9 @@ class UhdmAst {
 		// Indentation used for debug printing
 		std::string indent;
 
+		// Mapping of names that should be replaced to new names
+		std::unordered_map<std::string, std::string> node_renames;
+
 		// Functions that process specific types of nodes
 		void process_design();
 		void process_parameter();
@@ -126,7 +129,9 @@ class UhdmAst {
 		void process_int_typespec();
 		void process_bit_typespec();
 
-		UhdmAst(UhdmAst* p, UhdmAstShared& s, const std::string& i) : parent(p), shared(s), indent(i) {}
+		UhdmAst(UhdmAst* p, UhdmAstShared& s, const std::string& i) : parent(p), shared(s), indent(i) {
+			if (parent) node_renames = parent->node_renames;
+		}
 
 	public:
 		UhdmAst(UhdmAstShared& s, const std::string& i = "") : UhdmAst(nullptr, s, i) {}

--- a/uhdm-plugin/uhdmastshared.h
+++ b/uhdm-plugin/uhdmastshared.h
@@ -40,13 +40,6 @@ class UhdmAstShared {
 		// Top nodes of the design (modules, interfaces)
 		std::unordered_map<std::string, AST::AstNode*> top_nodes;
 
-		// Templates for top nodes of the design (in case there are multiple
-		// versions, e.g. for different parameters)
-		std::unordered_map<std::string, AST::AstNode*> top_node_templates;
-
-		// Map from already visited UHDM nodes to AST nodes
-		std::unordered_map<const UHDM::BaseClass*, AST::AstNode*> visited;
-
 		// UHDM node coverage report
 		UhdmAstReport report;
 


### PR DESCRIPTION
This includes for loop fixes required for OpenTitan modules:
```
ibex_icache.sv
ibex_dummy_instr.sv
sram2tlul.sv
aes_core.sv
aes_reg_pkg.sv
aes_reg_top.sv
aes_sbox.sv
aes_sbox_lut.sv
aes_sbox_canright.sv
aes_sbox_canright_masked_noreuse.sv
aes_sbox_canright_masked.sv
aes.sv
```
as well as memory usage optimizations and memory leak fixes.
PR in integration repo: https://github.com/antmicro/yosys-uhdm-plugin-integration/pull/41