### PR TITLE
Ignore delay controls

### DIFF
--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -2342,6 +2342,7 @@ AST::AstNode* UhdmAst::process_object(vpiHandle obj_handle) {
 				  break;
 		case vpiHierPath: process_hier_path(); break;
 		case UHDM::uhdmimport: break;
+		case vpiDelayControl: break;
 		case vpiLogicTypespec: process_logic_typespec(); break;
 		case vpiIntTypespec: process_int_typespec(); break;
 		case vpiBitTypespec: process_bit_typespec(); break;


### PR DESCRIPTION
Make the UHDM frontend ignore delay controls, as vanilla Yosys does (and other synthesis tools).

This change would fix some failing tests in sv-tests (such as this one https://chipsalliance.github.io/sv-tests-results/#UhdmYosys|ivtest|regress-sv_br_gh277b_iv)