### PR TITLE
Revert "adding the missing type option for ast memory"

### DIFF
--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -1166,16 +1166,6 @@ void UhdmAst::process_array_net() {
 	while (vpiHandle net_h = vpi_scan(itr)) {
 		auto net_type = vpi_get(vpiType, net_h);
 		if (net_type == vpiLogicNet) {
-			vpiHandle typespec_h = vpi_handle(vpiTypespec, net_h);
-			if(typespec_h)
-			{
-				std::string name = vpi_get_str(vpiName, typespec_h);
-				sanitize_symbol_name(name);
-				auto wiretype_node = new AST::AstNode(AST::AST_WIRETYPE);
-				wiretype_node->str = name;
-				current_node->children.push_back(wiretype_node);
-			    current_node->is_custom_type=true;
-			}
 			current_node->is_logic = true;
 			current_node->is_signed = vpi_get(vpiSigned, net_h);
 			visit_range(net_h,
@@ -1203,7 +1193,7 @@ void UhdmAst::process_array_net() {
 					  [&](AST::AstNode* node) {
 						  current_node->children.push_back(node);
 					  });
-	if (current_node->children.size() >= 2) { // If there is 2 ranges, change type to AST_MEMORY
+	if (current_node->children.size() == 2) { // If there is 2 ranges, change type to AST_MEMORY
 		current_node->type = AST::AST_MEMORY;
 	}
 }


### PR DESCRIPTION
This commit makes ``tests/OneStruct`` from uhdm-integration to fail. This needs to be fixed first before resubmitting this change.

This reverts commit e527611f06276de4f97ffbf78706da85bab48290.