### PR TITLE
Change UHDM includes to the new standard UHDM include location.

### DIFF
--- a/uhdm-plugin/Makefile
+++ b/uhdm-plugin/Makefile
@@ -14,9 +14,7 @@ SOURCES = UhdmAst.cc \
 
 include ../Makefile_plugin.common
 
-CPPFLAGS += -std=c++17 -I${UHDM_INSTALL_DIR}/include/uhdm \
-			-I${UHDM_INSTALL_DIR}/include/uhdm/include \
-			-I${UHDM_INSTALL_DIR}/include/uhdm/headers \
+CPPFLAGS += -std=c++17 -I${UHDM_INSTALL_DIR}/include \
 			-I${UHDM_INSTALL_DIR}/include/surelog
 
 CXXFLAGS += -Wno-inconsistent-missing-override -Wno-unused-parameter

--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -6,9 +6,11 @@
 #include "UhdmAst.h"
 #include "frontends/ast/ast.h"
 #include "frontends/verilog/verilog_frontend.h"
-#include "headers/uhdm.h"
 #include "libs/sha1/sha1.h"
-#include "vpi_user.h"
+
+// UHDM
+#include <uhdm/uhdm.h>
+#include <uhdm/vpi_user.h>
 
 YOSYS_NAMESPACE_BEGIN
 

--- a/uhdm-plugin/UhdmAst.h
+++ b/uhdm-plugin/UhdmAst.h
@@ -5,8 +5,8 @@
 #include <vector>
 #undef cover
 
-#include "uhdm.h"
 #include "uhdmastshared.h"
+#include <uhdm/uhdm.h>
 
 YOSYS_NAMESPACE_BEGIN
 

--- a/uhdm-plugin/uhdmastreport.cc
+++ b/uhdm-plugin/uhdmastreport.cc
@@ -1,8 +1,8 @@
 #include "uhdmastreport.h"
-#include "BaseClass.h"
 #include "frontends/ast/ast.h"
 #include <fstream>
 #include <sys/stat.h>
+#include <uhdm/BaseClass.h>
 #include <unordered_set>
 
 YOSYS_NAMESPACE_BEGIN

--- a/uhdm-plugin/uhdmastreport.h
+++ b/uhdm-plugin/uhdmastreport.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <unordered_map>
 #undef cover
-#include "headers/uhdm.h"
+#include <uhdm/uhdm.h>
 
 YOSYS_NAMESPACE_BEGIN
 

--- a/uhdm-plugin/uhdmsurelogastfrontend.cc
+++ b/uhdm-plugin/uhdmsurelogastfrontend.cc
@@ -31,8 +31,8 @@
 #include <unistd.h>
 #endif
 
-#include "ErrorReporting/Report.h"
-#include "surelog.h"
+#include "surelog/ErrorReporting/Report.h"
+#include "surelog/surelog.h"
 
 namespace UHDM
 {


### PR DESCRIPTION
Since the following PRs
https://github.com/chipsalliance/UHDM/pull/488
https://github.com/chipsalliance/Surelog/pull/1827
... the new location of uhdm headers is prefixed with
uhdm, such as <uhdm/foo.h>

Signed-off-by: Henner Zeller <h.zeller@acm.org>