### PR TITLE
Handle non-synthesizable statements

### DIFF
--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -1436,6 +1436,9 @@ void UhdmAst::process_operation()
         case vpiCaseEqOp:
             current_node->type = AST::AST_EQX;
             break;
+        case vpiCaseNeqOp:
+            current_node->type = AST::AST_NEX;
+            break;
         case vpiGtOp:
             current_node->type = AST::AST_GT;
             break;

--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -2153,6 +2153,11 @@ void UhdmAst::process_hier_path()
     });
 }
 
+void UhdmAst::process_nonsynthesizable(const UHDM::BaseClass *object)
+{
+    log_warning("%s:%d: Non-synthesizable object of type '%s'\n", object->VpiFile().c_str(), object->VpiLineNo(), UHDM::VpiTypeName(obj_h).c_str());
+}
+
 void UhdmAst::process_logic_typespec()
 {
     current_node = make_ast_node(AST::AST_WIRE);
@@ -2416,6 +2421,7 @@ AST::AstNode *UhdmAst::process_object(vpiHandle obj_handle)
     case UHDM::uhdmimport:
         break;
     case vpiDelayControl:
+        process_nonsynthesizable(object);
         break;
     case vpiLogicTypespec:
         process_logic_typespec();

--- a/uhdm-plugin/UhdmAst.h
+++ b/uhdm-plugin/UhdmAst.h
@@ -126,6 +126,7 @@ class UhdmAst
     void process_bit_typespec();
     void process_string_var();
     void process_string_typespec();
+    void process_nonsynthesizable(const UHDM::BaseClass *object);
 
     UhdmAst(UhdmAst *p, UhdmAstShared &s, const std::string &i) : parent(p), shared(s), indent(i)
     {


### PR DESCRIPTION
Some of verilog statements are non-synthesizable. This PR will make udhm-plugin behavior consistent with yosys when it comes to non-synthesizable statements.